### PR TITLE
Implement replacement for AndroidDriver dropped in Selenium 2.40

### DIFF
--- a/build/pom.xml
+++ b/build/pom.xml
@@ -248,44 +248,4 @@
         </pluginManagement>
     </build>
 
-    <profiles>
-        <profile>
-            <id>jboss-staging-repository-group</id>
-
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-
-            <repositories>
-                <repository>
-                    <id>jboss-staging-repository-group</id>
-                    <name>JBoss Staging Repository Group</name>
-                    <url>https://repository.jboss.org/nexus/content/groups/staging</url>
-                    <layout>default</layout>
-                    <releases>
-                        <enabled>true</enabled>
-                        <updatePolicy>never</updatePolicy>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                        <updatePolicy>never</updatePolicy>
-                    </snapshots>
-                </repository>
-            </repositories>
-            <pluginRepositories>
-                <pluginRepository>
-                    <id>jboss-staging-repository-group</id>
-                    <name>JBoss Staging Repository Group</name>
-                    <url>https://repository.jboss.org/nexus/content/groups/staging</url>
-                    <releases>
-                        <enabled>true</enabled>
-                    </releases>
-                    <snapshots>
-                        <enabled>true</enabled>
-                    </snapshots>
-                </pluginRepository>
-            </pluginRepositories>
-        </profile>
-    </profiles>
-
 </project>

--- a/droidium-native/arquillian-droidium-native/pom.xml
+++ b/droidium-native/arquillian-droidium-native/pom.xml
@@ -30,6 +30,8 @@
 
     <!-- Properties -->
     <properties>
+        <version.selendroid>0.8.0</version.selendroid>
+
         <!-- Other versions -->
         <version.mockito>1.9.5</version.mockito>
     </properties>
@@ -67,6 +69,17 @@
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>
             <artifactId>arquillian-drone-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.extension</groupId>
+            <artifactId>arquillian-drone-webdriver</artifactId>
+        </dependency>
+
+        <!-- Selendroid Driver -->
+        <dependency>
+            <groupId>io.selendroid</groupId>
+            <artifactId>selendroid-client</artifactId>
+            <version>${version.selendroid}</version>
         </dependency>
 
         <!-- Arquillian dependencies -->

--- a/droidium-native/arquillian-droidium-native/src/main/java/org/arquillian/droidium/native_/DroidiumNativeExtension.java
+++ b/droidium-native/arquillian-droidium-native/src/main/java/org/arquillian/droidium/native_/DroidiumNativeExtension.java
@@ -31,6 +31,12 @@ import org.arquillian.droidium.native_.instrumentation.InstrumentationRemoveDeci
 import org.arquillian.droidium.native_.selendroid.SelendroidDeploymentInstaller;
 import org.arquillian.droidium.native_.selendroid.SelendroidDeploymentUninstaller;
 import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.drone.spi.Configurator;
+import org.jboss.arquillian.drone.spi.Destructor;
+import org.jboss.arquillian.drone.spi.Instantiator;
+import org.jboss.arquillian.drone.webdriver.factory.AndroidBrowserCapabilities;
+import org.jboss.arquillian.drone.webdriver.factory.AndroidDriverFactory;
+import org.jboss.arquillian.drone.webdriver.spi.BrowserCapabilities;
 
 /**
  * Arquillian Droidium Native extension
@@ -68,6 +74,12 @@ public class DroidiumNativeExtension implements LoadableExtension {
 
         // services
         builder.service(ActivityManagerProvider.class, DroidiumNativeActivityManagerProvider.class);
+
+        // Android driver
+        builder.service(BrowserCapabilities.class, AndroidBrowserCapabilities.class);
+        builder.service(Configurator.class, AndroidDriverFactory.class);
+        builder.service(Instantiator.class, AndroidDriverFactory.class);
+        builder.service(Destructor.class, AndroidDriverFactory.class);
     }
 
 }

--- a/droidium-native/arquillian-droidium-native/src/main/java/org/jboss/arquillian/drone/webdriver/AndroidDriver.java
+++ b/droidium-native/arquillian-droidium-native/src/main/java/org/jboss/arquillian/drone/webdriver/AndroidDriver.java
@@ -1,0 +1,45 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.drone.webdriver;
+
+import io.selendroid.SelendroidDriver;
+
+import java.net.URL;
+
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+/**
+ * Injection point will be {@code AndroidDriver}.
+ *
+ * @author <a href="smikloso@redhat.com">Stefan Miklosovic</a>
+ *
+ */
+public class AndroidDriver extends SelendroidDriver {
+
+    public AndroidDriver(DesiredCapabilities caps) throws Exception {
+        super(caps);
+    }
+
+    public AndroidDriver(String url, DesiredCapabilities caps) throws Exception {
+        super(url, caps);
+    }
+
+    public AndroidDriver(URL url, DesiredCapabilities caps) throws Exception {
+        super(url.toExternalForm(), caps);
+    }
+
+}

--- a/droidium-native/arquillian-droidium-native/src/main/java/org/jboss/arquillian/drone/webdriver/factory/AndroidBrowserCapabilities.java
+++ b/droidium-native/arquillian-droidium-native/src/main/java/org/jboss/arquillian/drone/webdriver/factory/AndroidBrowserCapabilities.java
@@ -1,0 +1,51 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.drone.webdriver.factory;
+
+import io.selendroid.SelendroidCapabilities;
+
+import java.util.Map;
+
+import org.jboss.arquillian.drone.webdriver.spi.BrowserCapabilities;
+
+/**
+ * @author <a href="smikloso@redhat.com">Stefan Miklosovic</a>
+ *
+ */
+public class AndroidBrowserCapabilities implements BrowserCapabilities {
+
+    @Override
+    public int getPrecedence() {
+        return 0;
+    }
+
+    @Override
+    public String getImplementationClassName() {
+        return "org.jboss.arquillian.drone.webdriver.AndroidDriver";
+    }
+
+    @Override
+    public Map<String, ?> getRawCapabilities() {
+        return new SelendroidCapabilities().getRawCapabilities();
+    }
+
+    @Override
+    public String getReadableName() {
+        return "android";
+    }
+
+}

--- a/droidium-native/arquillian-droidium-native/src/main/java/org/jboss/arquillian/drone/webdriver/factory/AndroidDriverFactory.java
+++ b/droidium-native/arquillian-droidium-native/src/main/java/org/jboss/arquillian/drone/webdriver/factory/AndroidDriverFactory.java
@@ -1,0 +1,77 @@
+/**
+ * JBoss, Home of Professional Open Source
+ * Copyright 2014, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.arquillian.drone.webdriver.factory;
+
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jboss.arquillian.drone.spi.Configurator;
+import org.jboss.arquillian.drone.spi.Destructor;
+import org.jboss.arquillian.drone.spi.Instantiator;
+import org.jboss.arquillian.drone.webdriver.AndroidDriver;
+import org.jboss.arquillian.drone.webdriver.configuration.WebDriverConfiguration;
+import org.openqa.selenium.remote.DesiredCapabilities;
+
+/**
+ *
+ * @author <a href="smikloso@redhat.com">Stefan Miklosovic</a>
+ *
+ */
+public class AndroidDriverFactory extends AbstractWebDriverFactory<AndroidDriver> implements
+    Configurator<AndroidDriver, WebDriverConfiguration>,
+    Instantiator<AndroidDriver, WebDriverConfiguration>,
+    Destructor<AndroidDriver> {
+
+    private static final Logger log = Logger.getLogger(AndroidDriverFactory.class.getName());
+
+    private static final String BROWSER_CAPABILITIES = new AndroidBrowserCapabilities().getReadableName();
+
+    @Override
+    public int getPrecedence() {
+        return 0;
+    }
+
+    @Override
+    public void destroyInstance(AndroidDriver driver) {
+        driver.quit();
+    }
+
+    @Override
+    public AndroidDriver createInstance(WebDriverConfiguration configuration) {
+        URL remoteAddress = configuration.getRemoteAddress();
+
+        // default remote address
+        if (Validate.empty(remoteAddress)) {
+            remoteAddress = WebDriverConfiguration.DEFAULT_REMOTE_URL;
+            log.log(Level.INFO, "Property \"remoteAdress\" was not specified, using default value of {0}",
+                WebDriverConfiguration.DEFAULT_REMOTE_URL);
+        }
+
+        Validate.isValidUrl(remoteAddress, "Remote address must be a valid url, " + remoteAddress);
+
+        return SecurityActions.newInstance(configuration.getImplementationClass(),
+            new Class<?>[] { URL.class, DesiredCapabilities.class },
+            new Object[] { remoteAddress, new DesiredCapabilities(configuration.getCapabilities()) }, AndroidDriver.class);
+    }
+
+    @Override
+    protected String getDriverReadableName() {
+        return BROWSER_CAPABILITIES;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <version.arquillian.core>1.1.3.Final</version.arquillian.core>
 
         <!-- Arquillian Drone -->
-        <version.arquillian.drone>1.2.4.Final</version.arquillian.drone>
+        <version.arquillian.drone>1.3.0.Final</version.arquillian.drone>
 
         <!-- ShrinkWrap -->
         <version.shrinkwrap_shrinkwrap>1.2.0</version.shrinkwrap_shrinkwrap>


### PR DESCRIPTION
@kpiwko 

could you please briefly review this?

It seems it works without any flaws.
